### PR TITLE
Fix props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riduce",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Get rid of your reducer boilerplate! Zero hassle state management that's typed, flexible and scalable.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/proxy/createActionsProxy.ts
+++ b/src/proxy/createActionsProxy.ts
@@ -25,6 +25,8 @@ function createActionsProxy<
     wrapWithCreate(leafState, treeState, riducerDict, path),
     {
       get: (target, prop: Extract<keyof LeafT, string | number> | "create") => {
+        if (typeof prop === 'symbol') return undefined
+
         if (prop === 'toJSON') return () => "[[object ActionsProxy]]"
 
         if (prop === "create") return target.create;
@@ -40,10 +42,12 @@ function createActionsProxy<
   return (proxy as unknown) as ActionsProxy<LeafT, TreeT, RiducerDictT>;
 }
 
-const propForPath = (prop: string | number): string | number =>
+const propForPath = (prop: PropertyKey): string | number =>
   isFixedString(prop) ? parseInt(String(prop)) : String(prop);
 
-const isFixedString = (s: string | number) => {
+const isFixedString = (s: PropertyKey) => {
+  if (typeof s === 'symbol') return false
+
   // causes a bug in DevTools. idk how to fix. sorry.
   const n = Number(s);
   return !isNaN(n) && isFinite(n) && !/e/i.test(String(s));

--- a/src/riduce.test.ts
+++ b/src/riduce.test.ts
@@ -39,6 +39,11 @@ describe("Basic example", () => {
     expect(JSON.stringify(actions)).toBe(`"[[object ActionsProxy]]"`);
   });
 
+  test("actions returns undefined for Symbol.iterator", () => {
+    // @ts-ignore
+    expect(actions[Symbol.iterator]).toBeUndefined();
+  });
+
   describe("Reducer and actions update state appropriately", () => {
     test("Updating a boolean", () => {
       const result = reducer(


### PR DESCRIPTION
This PR handles `Symbol` props for `ActionProxy` (e.g. as used by React DevTools)